### PR TITLE
Render liquid in markdown mkdNonListItem cluster

### DIFF
--- a/syntax/jekyll_additions.vim
+++ b/syntax/jekyll_additions.vim
@@ -20,3 +20,6 @@ syntax region liquidObject start="{{" end="}}" contains=@Liquid keepend
 syntax region liquidTag start="{%" end="%}" contains=@Liquid keepend
 
 hi link frontMatter SpecialComment
+
+syntax cluster mkdNonListItem add=liquidObject
+syntax cluster mkdNonListItem add=liquidTag


### PR DESCRIPTION
All top level text in my markdown files is highlighted `mkdNonListItemBlock`, which is part of the `mkdNonListItem` cluster. Adding the two lines allows highlighting liquid inside these markdown blocks.